### PR TITLE
Compute CHM using rioxarray

### DIFF
--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import numpy as np
+import rioxarray
+from rasterio.enums import Resampling
+
+
+def compute_CHM(dsm_path, dtm_path, output_chm_path, resolution=None):
+    dtm = rioxarray.open_rasterio(dtm_path, masked=True)
+    dsm = rioxarray.open_rasterio(dsm_path, masked=True)
+
+    if resolution is not None:
+        # Not resampling should be applied
+        dtm_resampled = dtm
+    else:
+        # TODO consider a check to ensure the data is in a projected CRS
+        # Determine the current resolution
+        dtm_resolution = dtm.rio.resolution()
+        average_res = np.mean(np.abs(dtm_resolution))
+
+        # Determine the new pixel width and heights
+        upscale_factor = average_res / resolution
+        new_height = int(dtm.rio.height * upscale_factor)
+        new_width = int(dtm.rio.width * upscale_factor)
+
+        # Perform the resampling
+        dtm_resampled = dtm.rio.reproject(
+            dtm.rio.crs, shape=(new_height, new_width), resampling=Resampling.bilinear
+        )
+
+    # Pixel-align the dsm to the DTM
+    dsm_resampled = dsm.rio.reproject_match(dtm_resampled)
+
+    # Subtract the two products
+    chm = dsm_resampled - dtm_resampled
+    # Set all negative values to zero
+    chm = chm.clip(min=0)
+
+    # Save to disk
+    Path(output_chm_path).parent.mkdir(parents=True, exist_ok=True)
+    chm.rio.to_raster(output_chm_path)

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -29,8 +29,8 @@ def compute_CHM(
     dtm = rioxarray.open_rasterio(dtm_path, masked=True)
     dsm = rioxarray.open_rasterio(dsm_path, masked=True)
 
-    if resolution is not None:
-        # Not resampling should be applied
+    if resolution is None:
+        # No resampling should be applied
         dtm_resampled = dtm
     else:
         if dtm.rio.crs.is_geographic():

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -11,6 +11,7 @@ def compute_CHM(
     dtm_path: Union[str, Path],
     output_chm_path: Union[str, Path],
     resolution: Optional[float] = None,
+    clip_negative: bool = True,
 ):
     """Create a CHM by subtracting the DTM values from the DSM
 
@@ -24,6 +25,8 @@ def compute_CHM(
         resolution (Optional[float], optional):
             Spatial resolution of the CHM in meters. If unset, it will default to the resolution of
             the DSM. Defaults to None.
+        clip_negative (Optional[bool], optional):
+            Set all negative CHM values to 0. Defaults to True.
     """
     # Read the data
     dtm = rioxarray.open_rasterio(dtm_path, masked=True)

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -33,7 +33,10 @@ def compute_CHM(
         # Not resampling should be applied
         dtm_resampled = dtm
     else:
-        # TODO consider a check to ensure the data is in a projected CRS
+        if dtm.rio.crs.is_geographic():
+            raise ValueError(
+                "Reprojection of a geographic CRS to meter units will fail"
+            )
         # Determine the current resolution
         dtm_resolution = dtm.rio.resolution()
         average_res = np.mean(np.abs(dtm_resolution))

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -1,11 +1,31 @@
 from pathlib import Path
+from typing import Optional, Union
 
 import numpy as np
 import rioxarray
 from rasterio.enums import Resampling
 
 
-def compute_CHM(dsm_path, dtm_path, output_chm_path, resolution=None):
+def compute_CHM(
+    dsm_path: Union[str, Path],
+    dtm_path: Union[str, Path],
+    output_chm_path: Union[str, Path],
+    resolution: Optional[float] = None,
+):
+    """Create a CHM by subtracting the DTM values from the DSM
+
+    Args:
+        dsm_path (Union[str, Path]):
+            Path to read the DSM from
+        dtm_path (Union[str, Path]):
+            Path to read the DTM from
+        output_chm_path (Union[str, Path]):
+            Path to write the newly-computed CHM to
+        resolution (Optional[float], optional):
+            Spatial resolution of the CHM in meters. If unset, it will default to the resolution of
+            the DTM. Defaults to None.
+    """
+    # Read the data
     dtm = rioxarray.open_rasterio(dtm_path, masked=True)
     dsm = rioxarray.open_rasterio(dsm_path, masked=True)
 

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -33,7 +33,7 @@ def compute_CHM(
         # No resampling should be applied
         dtm_resampled = dtm
     else:
-        if dtm.rio.crs.is_geographic():
+        if dtm.rio.crs.is_geographic:
             raise ValueError(
                 "Reprojection of a geographic CRS to meter units will fail"
             )

--- a/ground_reference_prep/1_compute_CHM.py
+++ b/ground_reference_prep/1_compute_CHM.py
@@ -23,45 +23,43 @@ def compute_CHM(
             Path to write the newly-computed CHM to
         resolution (Optional[float], optional):
             Spatial resolution of the CHM in meters. If unset, it will default to the resolution of
-            the DTM. Defaults to None.
+            the DSM. Defaults to None.
     """
     # Read the data
     dtm = rioxarray.open_rasterio(dtm_path, masked=True)
     dsm = rioxarray.open_rasterio(dsm_path, masked=True)
-
     if resolution is None:
         # No resampling should be applied
-        dtm_resampled = dtm
+        dsm_resampled = dsm
     else:
-        if dtm.rio.crs.is_geographic:
+        if dsm.rio.crs.is_geographic:
             raise ValueError(
                 "Reprojection of a geographic CRS to meter units will fail"
             )
         # Determine the current resolution
-        dtm_resolution = dtm.rio.resolution()
-        average_res = np.mean(np.abs(dtm_resolution))
+        average_dsm_resolution = np.mean(np.abs(dsm.rio.resolution()))
 
         # Determine the new pixel width and heights
-        scale_factor = average_res / resolution
-        new_height = int(dtm.rio.height * scale_factor)
-        new_width = int(dtm.rio.width * scale_factor)
+        scale_factor = average_dsm_resolution / resolution
+        new_height = int(dsm.rio.height * scale_factor)
+        new_width = int(dsm.rio.width * scale_factor)
 
         # Use an averaging filter for downsampling and bicubic for upsampling
         resampling = Resampling.average if scale_factor < 1 else Resampling.cubic
         # Perform the resampling
-        dtm_resampled = dtm.rio.reproject(
-            dtm.rio.crs, shape=(new_height, new_width), resampling=resampling
+        dsm_resampled = dsm.rio.reproject(
+            dsm.rio.crs, shape=(new_height, new_width), resampling=resampling
         )
 
-    # Determine if the DSM has a higher resolution than the resampled DTM
+    # Determine if the DTM has a higher resolution than the resampled DSM
     # TODO consider how to make this more robust to data that's in geographic coordinates
-    dsm_higher_resolution = np.mean(np.abs(dsm.rio.resolution())) < np.mean(
-        np.abs(dtm_resampled.rio.resolution())
+    dtm_higher_resolution = np.mean(np.abs(dtm.rio.resolution())) < np.mean(
+        np.abs(dsm_resampled.rio.resolution())
     )
     # If the DSM is higher resolution it will be coarstened, so use averaging. Else use bicubic.
-    resampling = Resampling.average if dsm_higher_resolution else Resampling.cubic
-    # Pixel-align the dsm to the DTM
-    dsm_resampled = dsm.rio.reproject_match(dtm_resampled, resampling=resampling)
+    resampling = Resampling.average if dtm_higher_resolution else Resampling.cubic
+    # Pixel-align the DTM to the DSM
+    dtm_resampled = dtm.rio.reproject_match(dsm_resampled, resampling=resampling)
 
     # Subtract the two products
     chm = dsm_resampled - dtm_resampled


### PR DESCRIPTION
This roughly follows the logic [here](https://github.com/open-forest-observatory/ofo-catalog-data-prep/blob/c0a7733965a0528e67deaa084ca7e80fbbec52d6/deploy/drone-imagery-ingestion/03_photogrammetry/src/20_postprocess-photogrammetry-products.R#L43) but additionally adds the option to set a spatial resolution for the output CHM. Also, it threshold the values at 0, which I saw implemented in a different CHM method. Is the latter desirable?

Also, thanks @youngdjn for the suggestion to look into `rioxarray`. It seems quite powerful.