### PR TITLE
Add a driver script to run `get_mission_altitude`

### DIFF
--- a/1_preprocessing/1_get_mission_altitude.py
+++ b/1_preprocessing/1_get_mission_altitude.py
@@ -86,7 +86,7 @@ def main(camera_file, dtm_file, output_csv, verbose):
             "max": np.max(heights_np),
             "median": np.median(heights_np),
             "cv": cv,
-            "corr_ground_vs_camera_elevation": correlation
+            "flight_terrain_correlation_photogrammetry": correlation
         }
 
         print("Height above ground summary stats:")
@@ -95,9 +95,9 @@ def main(camera_file, dtm_file, output_csv, verbose):
 
     # Prepare the data as a single-row dictionary
     summary_row = {
-        "mean_height_above_ground": np.mean(heights_np),
-        "cv_height_above_ground": cv,
-        "corr_ground_vs_camera_elevation": correlation
+        "mean_altitude": np.mean(heights_np),
+        "cv_altitude": cv,
+        "flight_terrain_correlation_photogrammetry": correlation
     }
 
     # Convert to DataFrame and export as CSV

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -1,28 +1,26 @@
 import subprocess
 import os
-import shutil
 import re
+import tempfile
 from tqdm import tqdm
 
-
+# Path to parent remote folder with all missions
 remote = "js2s3:ofo-public/drone/missions_01"
-local_tmp = "/ofo-share/scratch-amritha/tree-species-scratch/tmp"
+# Local paths to save outputs
 output_dir = "/ofo-share/scratch-amritha/tree-species-scratch/mission_altitudes"
 failed_log_path = "/ofo-share/scratch-amritha/tree-species-scratch/failed_missions.txt"
 
-
-os.makedirs(local_tmp, exist_ok=True)
 os.makedirs(output_dir, exist_ok=True)
 
 # List to track failed missions
 failed_missions = []
 
-# List all folders under remote
+# List all folders from remote
 list_cmd = ["rclone", "lsf", remote]
-result = subprocess.run(list_cmd, capture_output=True, text=True)
-
+result = subprocess.run(list_cmd, capture_output=True, text=True, check=True)
 folders = [line.strip("/") for line in result.stdout.splitlines() if re.match(r"\d+", line)]
-# Iterate through each folder and set paths to camera, dtm and output files
+
+# Iterate through folders
 for folder in tqdm(folders):
     mission_id = f"{folder}_01"
     base_remote_path = f"{remote}/{folder}/processed_01/full"
@@ -30,48 +28,56 @@ for folder in tqdm(folders):
     dtm_file = f"{mission_id}_dtm-ptcloud.tif"
     output_csv = os.path.join(output_dir, f"{mission_id}_altitude_summary.csv")
 
-    # Skip if output already exists
+    # Skip already processed missions
     if os.path.exists(output_csv):
         continue
 
+    # Remote file paths
     camera_remote = f"{base_remote_path}/{camera_file}"
     dtm_remote = f"{base_remote_path}/{dtm_file}"
-    camera_local = os.path.join(local_tmp, camera_file)
-    dtm_local = os.path.join(local_tmp, dtm_file)
 
-    # Try downloading both files
-    subprocess.run(["rclone", "copyto", camera_remote, camera_local], check=True)
-    subprocess.run(["rclone", "copyto", dtm_remote, dtm_local], check=True)
-    # Check if files exist after download
-    if not (os.path.exists(camera_local) and os.path.exists(dtm_local)):
-        print(f"Download failed for {mission_id}.")
-        failed_missions.append((mission_id, "Missing files"))
-        continue
-
-
-    # Run the altitude calculation script
     try:
+        # Create temp files
+        with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp_camera, \
+             tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp_dtm:
+
+            camera_local = tmp_camera.name
+            dtm_local = tmp_dtm.name
+
+        # Download files to temporary paths
+        subprocess.run(["rclone", "copyto", camera_remote, camera_local], check=True)
+        subprocess.run(["rclone", "copyto", dtm_remote, dtm_local], check=True)
+
+        # Confirm files exist
+        if not (os.path.exists(camera_local) and os.path.exists(dtm_local)):
+            failed_missions.append((mission_id, "Missing files"))
+            continue
+        
+        # Run script to get the mission altitude
         subprocess.run([
-            "python3", "1_get_mission_altitude.py",
+            "python", "1_get_mission_altitude.py",
             "--camera-file", camera_local,
             "--dtm-file", dtm_local,
             "--output-csv", output_csv
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
     except subprocess.CalledProcessError:
+        # During ValueError when more than 10% of camera points fall outside the DTM extent
         failed_missions.append((mission_id, "Altitude computation failed"))
 
-    # Delete the temporary files
-    for path in [camera_local, dtm_local]:
-        try:
-            os.remove(path)
-        except FileNotFoundError:
-            pass
+    finally:
+        # Clean up temporary files
+        for tmp_path in [camera_local, dtm_local]:
+            try:
+                os.remove(tmp_path)
+            except FileNotFoundError:
+                pass
 
-# Log failed missions
+# Write failure log
 if failed_missions:
     with open(failed_log_path, "w") as f:
-        for id, reason in failed_missions:
-            f.write(f"{id},{reason}\n")
+        for mid, reason in failed_missions:
+            f.write(f"{mid},{reason}\n")
     print(f"Some missions failed. See '{failed_log_path}' for details.")
 else:
     print("All missions processed successfully!")

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -1,0 +1,77 @@
+import subprocess
+import os
+import shutil
+import re
+from tqdm import tqdm
+
+
+remote = "js2s3:ofo-public/drone/missions_01"
+local_tmp = "/ofo-share/scratch-amritha/tree-species-scratch/tmp"
+output_dir = "/ofo-share/scratch-amritha/tree-species-scratch/mission_altitudes"
+failed_log_path = "/ofo-share/scratch-amritha/tree-species-scratch/failed_missions.txt"
+
+
+os.makedirs(local_tmp, exist_ok=True)
+os.makedirs(output_dir, exist_ok=True)
+
+# List to track failed missions
+failed_missions = []
+
+# List all folders under remote
+list_cmd = ["rclone", "lsf", remote]
+result = subprocess.run(list_cmd, capture_output=True, text=True)
+
+folders = [line.strip("/") for line in result.stdout.splitlines() if re.match(r"\d+", line)]
+# Iterate through each folder and set paths to camera, dtm and output files
+for folder in tqdm(folders):
+    mission_id = f"{folder}_01"
+    base_remote_path = f"{remote}/{folder}/processed_01/full"
+    camera_file = f"{mission_id}_cameras.xml"
+    dtm_file = f"{mission_id}_dtm-ptcloud.tif"
+    output_csv = os.path.join(output_dir, f"{mission_id}_altitude_summary.csv")
+
+    # Skip if output already exists
+    if os.path.exists(output_csv):
+        continue
+
+    camera_remote = f"{base_remote_path}/{camera_file}"
+    dtm_remote = f"{base_remote_path}/{dtm_file}"
+    camera_local = os.path.join(local_tmp, camera_file)
+    dtm_local = os.path.join(local_tmp, dtm_file)
+
+    # Try downloading both files
+    subprocess.run(["rclone", "copyto", camera_remote, camera_local], check=True)
+    subprocess.run(["rclone", "copyto", dtm_remote, dtm_local], check=True)
+    # Check if files exist after download
+    if not (os.path.exists(camera_local) and os.path.exists(dtm_local)):
+        print(f"Download failed for {mission_id}.")
+        failed_missions.append((mission_id, "Missing files"))
+        continue
+
+
+    # Run the altitude calculation script
+    try:
+        subprocess.run([
+            "python3", "1_get_mission_altitude.py",
+            "--camera-file", camera_local,
+            "--dtm-file", dtm_local,
+            "--output-csv", output_csv
+        ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        failed_missions.append((mission_id, "Altitude computation failed"))
+
+    # Delete the temporary files
+    for path in [camera_local, dtm_local]:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+# Log failed missions
+if failed_missions:
+    with open(failed_log_path, "w") as f:
+        for id, reason in failed_missions:
+            f.write(f"{id},{reason}\n")
+    print(f"Some missions failed. See '{failed_log_path}' for details.")
+else:
+    print("All missions processed successfully!")

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -7,8 +7,8 @@ from tqdm import tqdm
 # Path to parent remote folder with all missions
 remote = "js2s3:ofo-public/drone/missions_01"
 # Local paths to save outputs
-output_dir = "/ofo-share/scratch-amritha/tree-species-scratch/mission_altitudes"
-failed_log_path = "/ofo-share/scratch-amritha/tree-species-scratch/failed_missions.txt"
+output_dir = "/ofo-share/scratch-amritha/tree-species-scratch/mission_altitudes2"
+failed_log_path = "/ofo-share/scratch-amritha/tree-species-scratch/failed_missions2.txt"
 
 os.makedirs(output_dir, exist_ok=True)
 
@@ -18,15 +18,16 @@ failed_missions = []
 # List all folders from remote
 list_cmd = ["rclone", "lsf", remote]
 result = subprocess.run(list_cmd, capture_output=True, text=True, check=True)
-folders = [line.strip("/") for line in result.stdout.splitlines() if re.match(r"\d+", line)]
+# Determine mission IDs to evaluate
+mission_ids = [line.strip("/") for line in result.stdout.splitlines() if re.match(r"\d+", line)]
 
 # Iterate through folders
-for folder in tqdm(folders):
-    mission_id = f"{folder}_01"
-    base_remote_path = f"{remote}/{folder}/processed_01/full"
-    camera_file = f"{mission_id}_cameras.xml"
-    dtm_file = f"{mission_id}_dtm-ptcloud.tif"
-    output_csv = os.path.join(output_dir, f"{mission_id}_altitude_summary.csv")
+for mission_id in tqdm(mission_ids):
+    mission_id_folder = f"{mission_id}_01"
+    base_remote_path = f"{remote}/{mission_id}/processed_01/full"
+    camera_file = f"{mission_id_folder}_cameras.xml"
+    dtm_file = f"{mission_id_folder}_dtm-ptcloud.tif"
+    output_csv = os.path.join(output_dir, f"{mission_id_folder}_altitude_summary.csv")
 
     # Skip already processed missions
     if os.path.exists(output_csv):

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -13,6 +13,8 @@ from constants import (
     MISSIONS_OUTSIDE_DTM_LIST,
 )
 
+MISSION_ALTITUDES_FOLDER.mkdir(parents=True, exist_ok=True)
+
 # List to track failed missions
 failed_missions = []
 

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -13,20 +13,11 @@ from constants import (
     MISSIONS_OUTSIDE_DTM_LIST,
 )
 
-# Path to parent remote folder with all missions
-remote = ALL_MISSIONS_REMOTE_FOLDER
-
-# Local paths to save outputs
-output_dir = MISSION_ALTITUDES_FOLDER
-failed_log_path = MISSIONS_OUTSIDE_DTM_LIST
-
-output_dir.mkdir(parents=True, exist_ok=True)
-
 # List to track failed missions
 failed_missions = []
 
 # List all folders from remote
-list_cmd = ["rclone", "lsf", remote]
+list_cmd = ["rclone", "lsf", ALL_MISSIONS_REMOTE_FOLDER]
 result = subprocess.run(list_cmd, capture_output=True, text=True, check=True)
 # Determine mission IDs to evaluate
 mission_ids = [
@@ -36,10 +27,10 @@ mission_ids = [
 # Iterate through folders
 for mission_id in tqdm(mission_ids):
     mission_id_folder = f"{mission_id}_01"
-    base_remote_path = f"{remote}/{mission_id}/processed_01/full"
+    base_remote_path = f"{ALL_MISSIONS_REMOTE_FOLDER}/{mission_id}/processed_01/full"
     camera_file = f"{mission_id_folder}_cameras.xml"
     dtm_file = f"{mission_id_folder}_dtm-ptcloud.tif"
-    output_csv = output_dir / f"{mission_id_folder}_altitude_summary.csv"
+    output_csv = MISSION_ALTITUDES_FOLDER / f"{mission_id_folder}_altitude_summary.csv"
 
     # Skip already processed missions
     if output_csv.exists():
@@ -98,9 +89,9 @@ for mission_id in tqdm(mission_ids):
 
 # Write failure log
 if failed_missions:
-    with failed_log_path.open("w") as f:
+    with MISSIONS_OUTSIDE_DTM_LIST.open("w") as f:
         for mid, reason in failed_missions:
             f.write(f"{mid},{reason}\n")
-    print(f"Some missions failed. See '{failed_log_path}' for details.")
+    print(f"Some missions failed. See '{MISSIONS_OUTSIDE_DTM_LIST}' for details.")
 else:
     print("All missions processed successfully!")

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -41,15 +41,11 @@ for mission_id in tqdm(mission_ids):
     dtm_remote = f"{base_remote_path}/{dtm_file}"
 
     try:
-        # Create temp files
-        with tempfile.NamedTemporaryFile(
-            suffix=".xml", delete=False
-        ) as tmp_camera, tempfile.NamedTemporaryFile(
-            suffix=".tif", delete=False
-        ) as tmp_dtm:
+        tmp_camera = tempfile.NamedTemporaryFile(suffix=".xml")
+        tmp_dtm = tempfile.NamedTemporaryFile(suffix=".tif")
 
-            camera_local = Path(tmp_camera.name)
-            dtm_local = Path(tmp_dtm.name)
+        camera_local = Path(tmp_camera.name)
+        dtm_local = Path(tmp_dtm.name)
 
         # Download files to temporary paths
         subprocess.run(
@@ -78,14 +74,6 @@ for mission_id in tqdm(mission_ids):
         # Writes appropriate error to file. This is for missions that have missing files or
         # failed computing mission altitude because of the ValueError due to >10% of camera points outside DTM.
         failed_missions.append((mission_id, f"Error: {str(e)}"))
-
-    finally:
-        # Clean up temporary files
-        for tmp_path in [camera_local, dtm_local]:
-            try:
-                tmp_path.unlink()
-            except FileNotFoundError:
-                pass
 
 # Write failure log
 if failed_missions:

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -47,11 +47,6 @@ for folder in tqdm(folders):
         # Download files to temporary paths
         subprocess.run(["rclone", "copyto", camera_remote, camera_local], check=True)
         subprocess.run(["rclone", "copyto", dtm_remote, dtm_local], check=True)
-
-        # Confirm files exist
-        if not (os.path.exists(camera_local) and os.path.exists(dtm_local)):
-            failed_missions.append((mission_id, "Missing files"))
-            continue
         
         # Run script to get the mission altitude
         subprocess.run([
@@ -61,9 +56,10 @@ for folder in tqdm(folders):
             "--output-csv", output_csv
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    except subprocess.CalledProcessError:
-        # During ValueError when more than 10% of camera points fall outside the DTM extent
-        failed_missions.append((mission_id, "Altitude computation failed"))
+    except Exception as e:
+        # Writes appropriate error to file. This is for missions that have missing files or 
+        # failed computing mission altitude because of the ValueError due to >10% of camera points outside DTM.
+        failed_missions.append((mission_id, f"Error: {str(e)}"))
 
     finally:
         # Clean up temporary files

--- a/constants.py
+++ b/constants.py
@@ -16,5 +16,13 @@ IMAGERY_DATASETS_FOLDER = Path(
 RAW_FOLDER = Path(DATA_ROOT_FOLDER, "raw")
 GROUND_REFERENCE_FOLDER = Path(RAW_FOLDER, "ground-reference")
 
+# Path to parent remote folder with all missions
+ALL_MISSIONS_REMOTE_FOLDER = "js2s3:ofo-public/drone/missions_01"
+
 # Intermediate
 PHOTOGRAMMETRY_FOLDER = Path(DATA_ROOT_FOLDER, "intermediate", "photogrammetry")
+PREPROCESSING_FOLDER = Path(DATA_ROOT_FOLDER, "intermediate", "preprocessing")
+
+# Inputs for first preprocessing step 1_get_mission_altitude.py
+MISSION_ALTITUDES_FOLDER = Path(PREPROCESSING_FOLDER, "mission_altitudes")
+MISSIONS_OUTSIDE_DTM_LIST = Path("/ofo-share/scratch-amritha/tree-species-scratch/failed_missions3.txt")

--- a/constants.py
+++ b/constants.py
@@ -25,4 +25,4 @@ PREPROCESSING_FOLDER = Path(DATA_ROOT_FOLDER, "intermediate", "preprocessing")
 
 # Inputs for first preprocessing step 1_get_mission_altitude.py
 MISSION_ALTITUDES_FOLDER = Path(PREPROCESSING_FOLDER, "mission_altitudes")
-MISSIONS_OUTSIDE_DTM_LIST = Path("/ofo-share/scratch-amritha/tree-species-scratch/failed_missions3.txt")
+MISSIONS_OUTSIDE_DTM_LIST = Path(PREPROCESSING_FOLDER, "list_of_missions_outside_dtm.txt")


### PR DESCRIPTION
This adds the driver script for computing the altitude data across all missions. It uses `rclone` to fetch the data from JS2 S3 remote, writes to `tmp` folder using the [tempfile](https://docs.python.org/3/library/tempfile.html) package (suggested by @russelldj), runs `1_get_mission_altitude.py` for each cameras-dtm pair input and saves the output CSV file to the user-specified directory. Also creates a .txt file with a list of all missions that didn't run successfully if more than 10% of camera points fall outside the DTM extent.

Please let me know if I should rename the new script to something else or if I should push it to a parallel folder (and a name for that folder). 