### PR TITLE
Add flag to remove pointcloud in saved photogrammetry project

### DIFF
--- a/photogrammetry/1_produce_combined_photogrammetry.py
+++ b/photogrammetry/1_produce_combined_photogrammetry.py
@@ -47,6 +47,7 @@ def produce_combined_config(imagery_folder: Path):
         "project_path": str(project_folder),
         "run_name": run_name,
         "buildOrthomosaic": {"surface": ["DSM-ptcloud"]},
+        "buildPointCloud": {"remove_after_export": True},
     }
 
     output_config_file = Path(DERIVED_METASHAPE_CONFIGS_FOLDER, run_name + ".yml")


### PR DESCRIPTION
This removes the pointcloud from the Metashape project file. It would make it impossible to recreate the exact same result, but it has substantial storage savings. Suggested by @youngdjn.