### PR TITLE
Update drone mission and ground plot matching criteria

### DIFF
--- a/1_preprocessing/1_get_mission_altitude.py
+++ b/1_preprocessing/1_get_mission_altitude.py
@@ -77,6 +77,12 @@ def main(camera_file, dtm_file, output_csv, verbose):
     cv = np.std(heights_np) / np.mean(heights_np)
     correlation = np.corrcoef(ground_np, camera_np)[0, 1]  # Get value from the correlation matrix
 
+    # Compute sd_photogrammetry_altitude with 5th-95th percentile clipping
+    lower_bound = np.percentile(heights_np, 5)
+    upper_bound = np.percentile(heights_np, 95)
+    filtered_altitudes = heights_np[(heights_np >= lower_bound) & (heights_np <= upper_bound)]
+    sd_photogrammetry_altitude = np.std(filtered_altitudes)
+
     if verbose:
         stats = {
             "count": len(heights_np),
@@ -86,7 +92,8 @@ def main(camera_file, dtm_file, output_csv, verbose):
             "max": np.max(heights_np),
             "median": np.median(heights_np),
             "cv": cv,
-            "flight_terrain_correlation_photogrammetry": correlation
+            "flight_terrain_correlation_photogrammetry": correlation,
+            "sd_photogrammetry_altitude": sd_photogrammetry_altitude
         }
 
         print("Height above ground summary stats:")
@@ -97,7 +104,8 @@ def main(camera_file, dtm_file, output_csv, verbose):
     summary_row = {
         "mean_altitude": np.mean(heights_np),
         "cv_altitude": cv,
-        "flight_terrain_correlation_photogrammetry": correlation
+        "flight_terrain_correlation_photogrammetry": correlation,
+        "sd_photogrammetry_altitude": sd_photogrammetry_altitude
     }
 
     # Convert to DataFrame and export as CSV

--- a/1_preprocessing/1_get_mission_altitude_driver_script.py
+++ b/1_preprocessing/1_get_mission_altitude_driver_script.py
@@ -28,8 +28,8 @@ mission_ids = [
 
 # Iterate through folders
 for mission_id in tqdm(mission_ids):
-    mission_id_folder = f"{mission_id}_01"
-    base_remote_path = f"{ALL_MISSIONS_REMOTE_FOLDER}/{mission_id}/processed_01/full"
+    mission_id_folder = f"{mission_id}"
+    base_remote_path = f"{ALL_MISSIONS_REMOTE_FOLDER}/{mission_id}/processed_02/full"
     camera_file = f"{mission_id_folder}_cameras.xml"
     dtm_file = f"{mission_id_folder}_dtm-ptcloud.tif"
     output_csv = MISSION_ALTITUDES_FOLDER / f"{mission_id_folder}_altitude_summary.csv"

--- a/1_preprocessing/2_merge_alt_columns.py
+++ b/1_preprocessing/2_merge_alt_columns.py
@@ -1,0 +1,34 @@
+# This script is to merge the generated altitude data from individual files to the metadata file
+import sys
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+import os
+import glob
+import re
+
+# Add folder where constants.py is to system search path
+sys.path.append(str(Path(Path(__file__).parent, "..").resolve()))
+from constants import (DRONE_MISSIONS_WITH_ALT_FILE,
+                       ALL_MISSIONS_METADATA_FILE,
+                       MISSION_ALTITUDES_FOLDER)
+
+metadata_gdf = gpd.read_file(ALL_MISSIONS_METADATA_FILE)
+
+csv_files = glob.glob(os.path.join(MISSION_ALTITUDES_FOLDER, "*_altitude_summary.csv"))
+
+altitude_data = []
+for file_path in csv_files:
+    filename = os.path.basename(file_path)
+    match = re.match(r"(\d{6})_altitude_summary\.csv", filename)
+    if match:
+        mission_id = match.group(1)
+        df = pd.read_csv(file_path)
+        row = df.iloc[0]
+        row["mission_id"] = mission_id
+        altitude_data.append(row)
+
+altitude_df = pd.DataFrame(altitude_data)
+merged_gdf = metadata_gdf.merge(altitude_df, on="mission_id", how="left")  # keep all rows from left, match with right
+merged_gdf.to_file(DRONE_MISSIONS_WITH_ALT_FILE)

--- a/constants.py
+++ b/constants.py
@@ -41,6 +41,7 @@ MISSIONS_OUTSIDE_DTM_LIST = Path(
 )
 # Inputs for 4_pair_drone_with_ground.py
 GROUND_REFERENCE_PLOTS_FILE = Path(GROUND_REFERENCE_FOLDER, "ofo_ground-reference_plots.gpkg")
+ALL_MISSIONS_METADATA_FILE = Path("ofo-share/catalog-data-prep/01_raw-imagery-ingestion/metadata/3_final/ofo-all-missions-metadata.gpkg")
 DRONE_MISSIONS_WITH_ALT_FILE = Path(PREPROCESSING_FOLDER, "ofo-all-missions-metadata-with-altitude.gpkg")
 
 GROUND_PLOT_DRONE_MISSION_MATCHES_FILE = Path(INTERMEDIATE_DATA_FOLDER , "ground_plot_drone_mission_matches.csv")

--- a/ground_reference_prep/4_pair_drone_with_ground.py
+++ b/ground_reference_prep/4_pair_drone_with_ground.py
@@ -150,16 +150,7 @@ def pair_drone_missions(drone_missions_gdf):
         .dt.days
     )
 
-    # Sort so pairs with smaller date differences b/w missions come first
-    paired_valid_sorted = paired_valid.sort_values("date_diff_days")
-
-    # Only use each low-oblique mission once, retaining the pair with the closest (in time) nadir mission to it
-    # Note: This can have the same high-nadir mission matched to multiple low-oblique missions
-    paired_drone_missions_gdf = paired_valid_sorted.drop_duplicates(
-        subset="mission_id_2", keep="first"
-    )
-
-    return paired_drone_missions_gdf
+    return paired_valid
 
 
 def match_ground_plots_with_drone_missions(
@@ -228,6 +219,13 @@ def match_ground_plots_with_drone_missions(
         "earliest_date_derived_2": "earliest_date_derived_lo",
     }
     valid_pairs.rename(columns=paired_columns_rename, inplace=True)
+
+    # Sort so smallest date difference comes first
+    valid_pairs = valid_pairs.sort_values("year_diff")
+
+    # Ensure each LO mission is matched only once per ground plot
+    # For each (mission_id_lo, plot_id), keep only the row with the smallest year_diff
+    valid_pairs = valid_pairs.drop_duplicates(subset=["mission_id_lo", "plot_id"], keep="first")
 
     ground_plot_drone_missions_matches = valid_pairs[
         [

--- a/ground_reference_prep/4_pair_drone_with_ground.py
+++ b/ground_reference_prep/4_pair_drone_with_ground.py
@@ -135,6 +135,10 @@ def pair_drone_missions(drone_missions_gdf):
 
     paired_valid = paired[paired.apply(is_valid_pair, axis=1)].reset_index(drop=True)
 
+    # Force include pair 337 & 338
+    forced_pair = paired[(paired["mission_id_1"] == "000337") & (paired["mission_id_2"] == "000338")]
+    paired_valid = pd.concat([paired_valid, forced_pair], ignore_index=True)
+
     # Calculate absolute date difference
     paired_valid["date_diff_days"] = (
         (

--- a/ground_reference_prep/4_pair_drone_with_ground.py
+++ b/ground_reference_prep/4_pair_drone_with_ground.py
@@ -16,6 +16,7 @@ def classify_mission(row):
     altitude = row["mean_altitude"]
     pitch = row["camera_pitch_derived"]
     terrain_corr = row["flight_terrain_correlation_photogrammetry"]
+    sd_photogrammetry_altitude = row["sd_photogrammetry_altitude"]
     front_overlap = row["overlap_front_nominal"]
     side_overlap = row["overlap_side_nominal"]
 
@@ -29,22 +30,22 @@ def classify_mission(row):
     ):
         return "unknown"
 
-    # Must meet terrain fidelity requirement
-    if terrain_corr <= 0.75:
+    # Must meet terrain fidelity or SD requirement
+    if not (terrain_corr > 0.75 or sd_photogrammetry_altitude < 12):
         return "low-terrain-fidelity"
 
     # High-Nadir requirements
     if (
-        110 <= altitude <= 150
+        100 <= altitude <= 160
         and 0 <= pitch <= 10
-        and front_overlap >= 90
-        and side_overlap >= 80
+        and ((front_overlap >= 90 and side_overlap >= 80)
+        or (front_overlap >= 85 and side_overlap >= 85))
     ):
         return "high-nadir"
 
     # Low-Oblique requirements
     if (
-        60 <= altitude <= 100
+        60 <= altitude <= 120
         and 18 <= pitch <= 38
         and front_overlap >= 70
         and side_overlap >= 60

--- a/ground_reference_prep/4_pair_drone_with_ground.py
+++ b/ground_reference_prep/4_pair_drone_with_ground.py
@@ -211,7 +211,9 @@ def match_ground_plots_with_drone_missions(
     joined["year_diff"] = (
         joined["drone_date"].dt.year - joined["survey_date_parsed"].dt.year
     ).abs()
-    valid_pairs = joined[joined["year_diff"] <= 8]
+    
+    # Keep all plots from project NEON2023. Others must satisfy year difference check.
+    valid_pairs = joined[(joined["project_name"] == "NEON2023") | (joined["year_diff"] <= 8)]
 
     # Rename _1 to _hn and _2 to _lo
     paired_columns_rename = {


### PR DESCRIPTION
This PR implements the updates specified for pairing drone missions and matching with ground plots in the [species-prediction-data-prep](https://docs.google.com/document/d/1Uj1smcSaVvL3zWEz4CZCArFZ8n9kMMUIHIiFhf6hFdU/edit?usp=sharing) document.

The below changes were made:

1. I calculated `sd_photogrammetry_altitude` with 5th-95th percentile clipping for every mission and regenerated the altitude summary files saved to `/ofo-share/species-prediction-project/intermediate/preprocessing/mission_altitudes`
2. Merged this updated data with `ofo-all-missions-metadata.gpkg` and saved it to `DRONE_MISSIONS_WITH_ALT_FILE` using the newly added script `1_preprocessing/2_merge_alt_columns.py`. 
3. Updated `ground_reference_prep/4_pair_drone_with_ground.py` with new check for sd value (along with terrain_corr), changes to HN and LO mission ranges.
4. Force included pair 337 & 338. Ensured that it gets matched with plot 0059.
5. Retaining all plots from NEON2023 project, checking year difference for others.
6. Moved rejection of HN-LO pairs to `match_ground_plots_with_drone_missions` to ensure each LO mission is matched only once per ground plot

All the above changes resulted in 217 drone-mission-pair & ground-plot matches. Saved to `/ofo-share/species-prediction-project/intermediate/ground_plot_drone_mission_matches.csv`.

The intersection data for every set has been updated and saved to `/ofo-share/species-prediction-project/intermediate/raw_image_sets`