### PR TITLE
Update the photogrammetry to work with workflow orchestration

### DIFF
--- a/configs/path_config.py
+++ b/configs/path_config.py
@@ -11,16 +11,16 @@ class PathConfig:
     # Locations of installed dependencies
     automate_metashape_path: Path = Path("/ofo-share/repos-david/automate-metashape")
     metashape_python_path: Path = Path("/home/exouser/miniconda3/envs/meta/bin/python")
-    
+
     # This path can edited if working with a copy of the data
     data_root_folder: Path = Path("/ofo-share/species-prediction-project/")
-    
+
     # Inputs
     # TODO this could be updated to be within the DATA_ROOT_FOLDER tree
     imagery_datasets_folder: Path = Path(
         "/ofo-share/catalog-data-prep/01_raw-imagery-ingestion/2_sorted"
     )
-    
+
     # TODO consider renaming this to "inputs" if we want to be consistent with the NRS project
     raw_folder: Path = Path(data_root_folder, "raw")
     ground_reference_folder: Path = Path(raw_folder, "ground-reference")
@@ -34,7 +34,7 @@ class PathConfig:
 
     # Path to parent remote folder with all missions
     all_missions_remote_folder: str = "js2s3:ofo-public/drone/missions_01"
-    
+
     # Intermediate
     intermediate_data_folder: Path = Path(data_root_folder, "intermediate")
     overlapping_plots_file: Path = Path(
@@ -44,10 +44,15 @@ class PathConfig:
     preprocessing_folder: Path = Path(intermediate_data_folder, "preprocessing")
     raw_image_sets_folder: Path = Path(intermediate_data_folder, "raw_image_sets")
 
-    derived_metashape_configs_folder: Path = Path(
-        intermediate_data_folder, "metashape_configs"
-    )
-    
+    # This folder will be mounted into the containers
+    # Note that this needs to be a copy of raw_image_sets_folder. Currently this is done manually
+    # and then `raw_image_sets_folder` becomes a symlink to `argo_inputs_image_sets`
+    argo_inputs_image_sets: Path = Path("/ofo-share/argo-input/datasets")
+    # This will be the path within the container
+    argo_imagery_path: Path = Path("/data/argo-input/datasets")
+
+    derived_metashape_configs_folder: Path = Path("/ofo-share/argo-input/configs")
+
     # Inputs for first preprocessing step 01_get_mission_altitude.py
     mission_altitudes_folder: Path = Path(preprocessing_folder, "mission_altitudes")
     missions_outside_dtm_list: Path = Path(
@@ -67,7 +72,7 @@ class PathConfig:
 
     hdbscan_clustered_plots = Path(intermediate_data_folder, "hdbscan_clustered_plots.gpkg")
     train_test_split_file = Path(intermediate_data_folder, "train_test_split.csv")
-    
+
     drone_images_root: Path = Path(
         "/ofo-share/catalog-data-prep/01_raw-imagery-ingestion/2_sorted"
     )


### PR DESCRIPTION
Previously this photogrammetry step exported multiple sequential scripts that could be run to call `automate-metashape`. Now we're using Argo workflow orchestration ([here](https://github.com/open-forest-observatory/ofo-argo)) to schedule photogrammetry runs across multiple instances in a kubernetes cluster. This updates the pathing to work within the contain and eliminates some arguments (`run_name`, `project_path`, `output_path`) which are handled by workflow orchestration. Finally, the `photo_path_secondary` was eliminated and the sub-folders of both the oblique and nadir folders are added to `photo_path`. This is an algorithmic change because secondary alignment wasn't working. 