### PR TITLE
Change pathing to use argo-produced photogrammetry products

### DIFF
--- a/1_data_prep/04_compute_CHM.py
+++ b/1_data_prep/04_compute_CHM.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Optional, Union
-import sys
 
 import numpy as np
 import rioxarray
@@ -81,6 +80,11 @@ def compute_CHM(
 
 
 if __name__ == "__main__":
+    if not path_config.photogrammetry_folder.is_symlink():
+        # symlink from where argo produced the photogrammetry outputs to the working file tree
+        path_config.photogrammetry_folder.symlink_to(
+            path_config.photogrammetry_folder_argo
+        )
     # List all the folders, corresponding to photogrammetry for a nadir-oblique pair
     photogrammetry_run_folders = path_config.photogrammetry_folder.glob("*_*")
     # Iterate over the folders

--- a/1_data_prep/12_render_instance_ids.py
+++ b/1_data_prep/12_render_instance_ids.py
@@ -33,6 +33,11 @@ LABEL_COLUMN_NAME = "unique_ID"
 VIS = True
 
 if __name__ == "__main__":
+    if not path_config.photogrammetry_folder.is_symlink():
+        # symlink from where argo produced the photogrammetry outputs to the working file tree
+        path_config.photogrammetry_folder.symlink_to(
+            path_config.photogrammetry_folder_argo
+        )
     photogrammetry_folders = path_config.photogrammetry_folder.glob("*")
 
     for photogrammetry_folder in photogrammetry_folders:

--- a/configs/path_config.py
+++ b/configs/path_config.py
@@ -40,7 +40,8 @@ class PathConfig:
     overlapping_plots_file: Path = Path(
         intermediate_data_folder, "ground_plot_drone_mission_matches.csv"
     )
-    photogrammetry_folder: Path = Path("/ofo-share/argo-output/species_project")
+    photogrammetry_folder_argo: Path = Path("/ofo-share/argo-output/species_project")
+    photogrammetry_folder: Path = Path(intermediate_data_folder, "photogrammetry")
     preprocessing_folder: Path = Path(intermediate_data_folder, "preprocessing")
     raw_image_sets_folder: Path = Path(intermediate_data_folder, "raw_image_sets")
 


### PR DESCRIPTION
This changes a bit of pathing logic to reflect the organization of the photogrammetry data produced using our workflow automation tool, Argo. The repo can be found [here](https://github.com/open-forest-observatory/ofo-argo).

It also renames the `mesh_CRS` argument in the rendering step and adds the `original_image_folder` argument to deal with the fact that the image paths change within the container. 