### PR TITLE
Don't suppress edge detections if there's only one tile

### DIFF
--- a/1_data_prep/07_tree_detection.py
+++ b/1_data_prep/07_tree_detection.py
@@ -18,8 +18,8 @@ from tree_detection_framework.preprocessing.preprocessing import (
 import _bootstrap
 from configs.path_config import path_config
 
-CHIP_SIZE = 1000
-CHIP_STRIDE = 900
+CHIP_SIZE = 2000
+CHIP_STRIDE = 1900
 RESOLUTION = 0.2
 
 


### PR DESCRIPTION
On the current branch, there's an issue where lots of regions at the edge are excluded during tree detection. This is because we drop detections at the border of each tile so they are non-overlapping between tiles. However, in this case we have very large tiles and it's a problem that content at the borders of the scene is dropped entirely. An example can be seen below.
<img width="512" height="474" alt="image" src="https://github.com/user-attachments/assets/be6b67a3-fdcf-43b8-8fca-b74827f2e67d" />
Something which exacerbated this issue was me setting the stride low, since this shrinks the "core" area of each tile. I updated to make the stride larger and not do suppression if there's only one tile. This worked.
<img width="627" height="632" alt="image" src="https://github.com/user-attachments/assets/b4705297-2be5-4050-8a76-f0a1edb8f5b5" />

