### PR TITLE
Remove `geograypher` dependency from derived altitude extraction

### DIFF
--- a/1_data_prep/_get_mission_altitude.py
+++ b/1_data_prep/_get_mission_altitude.py
@@ -1,4 +1,5 @@
 import argparse
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import geopandas as gpd
@@ -6,7 +7,6 @@ import numpy as np
 import pandas as pd
 import rasterio as rio
 import shapely
-import xml.etree.ElementTree as ET
 
 
 def make_4x4_transform(rotation_str: str, translation_str: str, scale_str: str = "1"):

--- a/1_data_prep/_get_mission_altitude.py
+++ b/1_data_prep/_get_mission_altitude.py
@@ -1,11 +1,11 @@
 import argparse
+from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rasterio as rio
 import shapely
-from shapely.geometry import Point
 import xml.etree.ElementTree as ET
 
 
@@ -210,26 +210,18 @@ def main(camera_file, dtm_file, output_csv, verbose):
     summary_df = pd.DataFrame([summary_row])
 
     # Ensure output directory exists and save the summary
-    ensure_containing_folder(output_csv)
+    Path(output_csv).parent.mkdir(parents=True, exist_ok=True)
     summary_df.to_csv(output_csv, index=False)
 
     print(f"Summary exported to {output_csv}")
 
 
-get_camera_locations(
-    "/ofo-share/argo-data/argo-output/species_project/0001_001435_001436/output/0001_001435_001436_cameras.xml"
-)
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Compute height above ground for cameras and export summary statistics."
     )
-    parser.add_argument(
-        "--camera-file", default=EXAMPLE_CAMERAS_FILENAME, help="Path to camera file"
-    )
-    parser.add_argument(
-        "--dtm-file", default=EXAMPLE_DTM_FILE, help="Path to DTM raster file"
-    )
+    parser.add_argument("--camera-file", help="Path to camera file")
+    parser.add_argument("--dtm-file", help="Path to DTM raster file")
     parser.add_argument(
         "--output-csv",
         default="altitude_summary.csv",


### PR DESCRIPTION
The initial approach to derived altitude extraction relied on importing geograypher. Since the vast majority of the goegraypher dependencies are not used for this task, and we might want to do this task in other pipelines, I refactored this into a standalone operation. This is largely a subset of the geograypher code, but does contain some slight improvements. 

@youngdjn , do you have any thoughts for a more permanent location for this code? I was initially thinking [ofo-catalog-data-prep](https://github.com/open-forest-observatory/ofo-catalog-data-prep) but I know that's almost entirely `R` at this point.